### PR TITLE
Fix the folder name dots issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,12 @@ function isDir(fp, stat) {
     return true;
   }
 
+  if (stat === null) {
+    // try to get the directory info if it hasn't been done yet
+    // to ensure directories containing dots are well handle
+    stat = tryStats(fp);
+  }
+
   if (stat != null && typeof stat === 'object') {
     return stat.isDirectory();
   }


### PR DESCRIPTION
> This PR will also fix the assemble/assemble#691 issue.

Here are the steps to reproduce the issue before patching.

if your terminal current directory is the `relative` project directory, then

```js
$ cd fixtures/a.b.c/
$ node
> require('../../index.js')('a.txt')
'a.b.c/a.txt'
```

which is wrong because you should get `a.txt` !

Then with the patch in this PR, you'll get

```js
$ cd fixtures/a.b.c/
$ node
> require('../../index.js')('a.txt')
'a.txt'
```

Cheers